### PR TITLE
feat: Add timed developer joke to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
                 </a>
             </div>
+            <div id="joke-container"></div>
         </main>
     </div>
 
@@ -86,6 +87,34 @@
                 });
             });
         }
+    </script>
+
+    <script>
+        const jokes = [
+            "Why do programmers prefer dark mode? Because light attracts bugs!",
+            "Why was the JavaScript developer sad? Because he didn't Node how to Express himself.",
+            "What's a programmer's favorite hangout place? Foo Bar.",
+            "Why did the private classes break up? Because they never saw each other.",
+            "How many programmers does it take to change a light bulb? None, that's a hardware problem.",
+            "Why do Java developers wear glasses? Because they don't C#.",
+            "What's the object-oriented way to become wealthy? Inheritance."
+        ];
+
+        function displayJoke() {
+            const jokeContainer = document.getElementById('joke-container');
+            if (jokeContainer) {
+                const randomIndex = Math.floor(Math.random() * jokes.length);
+                jokeContainer.innerHTML = jokes[randomIndex];
+                jokeContainer.classList.add('joke-visible');
+
+                setTimeout(() => {
+                    jokeContainer.classList.remove('joke-visible');
+                }, 7000); // Hide after 7 seconds
+            }
+        }
+
+        // Wait for 10 seconds after page load, then display a joke
+        setTimeout(displayJoke, 10000); // Display joke after 10 seconds
     </script>
 </body>
 </html>

--- a/styles/hkdev.css
+++ b/styles/hkdev.css
@@ -178,3 +178,29 @@ https://web.dev/articles/speedy-css-tip-animated-gradient-text
     }
   }
 }
+
+/* Joke Container Styles */
+#joke-container {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 10px 20px;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: #f0f0f0;
+  border-radius: 8px;
+  font-size: 0.9em;
+  text-align: center;
+  z-index: 1000;
+  visibility: hidden;
+  opacity: 0;
+  /* Delay visibility transition to allow opacity to fade out smoothly */
+  transition: visibility 0s linear 0.5s, opacity 0.5s ease-in-out;
+}
+
+#joke-container.joke-visible {
+  visibility: visible;
+  opacity: 1;
+  /* Shorter transition for fade-in, no delay for visibility */
+  transition: opacity 0.5s ease-in-out;
+}


### PR DESCRIPTION
Injects a developer joke into the homepage 10 seconds after a visitor arrives. The joke appears subtly at the bottom-center of the page with a fade-in animation. It automatically disappears with a fade-out animation after 7 seconds.

Key changes:
- Added a div#joke-container to index.html, initially hidden by CSS.
- Implemented JavaScript in index.html to:
    - Store a list of developer jokes.
    - Randomly select and display a joke in div#joke-container.
    - Manage timing for the appearance (10s delay) and disappearance (7s duration).
- Added CSS styles in styles/hkdev.css for:
    - Positioning and subtle styling of the joke container.
    - Fade-in and fade-out animations using CSS transitions on opacity and visibility.
- Updated JavaScript to use class toggling (.joke-visible) to trigger CSS animations.