### PR TITLE
Add animated shine effect to hero card

### DIFF
--- a/styles/hkdev.css
+++ b/styles/hkdev.css
@@ -88,6 +88,43 @@ main { flex: 1; display: flex; align-items: center; justify-content: center; }
   z-index: 0;
 }
 
+.hero-card:after {
+  content: '';
+  position: absolute;
+  inset: -35%;
+  pointer-events: none;
+  background: linear-gradient(
+    120deg,
+    transparent 34%,
+    rgba(56,189,248,0.05) 43%,
+    rgba(191,219,254,0.18) 48%,
+    rgba(255,255,255,0.24) 50%,
+    rgba(125,211,252,0.18) 52%,
+    rgba(56,189,248,0.05) 57%,
+    transparent 66%
+  );
+  transform: translateX(-130%) rotate(14deg);
+  transform-origin: center;
+  opacity: 0.8;
+  z-index: 1;
+  animation: hero-card-shine 13s ease-in-out infinite;
+}
+
+@keyframes hero-card-shine {
+  0%,
+  8% {
+    transform: translateX(-130%) rotate(14deg);
+  }
+
+  23% {
+    transform: translateX(130%) rotate(14deg);
+  }
+
+  100% {
+    transform: translateX(130%) rotate(14deg);
+  }
+}
+
 .profile-image-container { text-align: center; }
 .profile-image { width: 140px; height: 140px; border-radius: 32%; border: 4px solid var(--color-border); padding: 12px; background: var(--color-bg-alt); box-shadow: var(--shadow-sm); transition: transform .4s; position: relative; }
 /* Fallback: if white SVG served in light mode apply soft tint */
@@ -188,6 +225,19 @@ main { flex: 1; display: flex; align-items: center; justify-content: center; }
 @media (prefers-color-scheme: dark) {
   .portfolio-btn { background: var(--color-bg-alt); color: var(--color-text-soft); }
   .portfolio-btn:hover { background: var(--color-bg); }
+
+  .hero-card:after {
+    background: linear-gradient(
+      120deg,
+      transparent 33%,
+      rgba(59,130,246,0.04) 43%,
+      rgba(96,165,250,0.12) 48%,
+      rgba(255,255,255,0.16) 50%,
+      rgba(125,211,252,0.1) 52%,
+      rgba(59,130,246,0.04) 57%,
+      transparent 67%
+    );
+  }
 }
 
 /* Social Links */
@@ -221,6 +271,10 @@ a:hover { text-decoration: underline; }
 
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { animation: none !important; transition: none !important; }
+
+  .hero-card:after {
+    opacity: 0;
+  }
 }
 
 /* Utility */


### PR DESCRIPTION
## Summary
- add a diagonal shine overlay to the main hero card
- slow the animation cadence so the initial shine runs on load and repeats after a pause
- use a slightly more colorful blue-cyan highlight with dark mode and reduced-motion handling

## Testing
- npm run lint
- npm run lint:css